### PR TITLE
docs: Update repository name and correct paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ The results are provided via a REST API built with FastAPI.
 
 1. リポジトリをクローン
 ```bash
-git clone <repository-url>
-cd six-degrees-of-defeat
+git clone git@github.com:j341nono/six-degrees-of-defeat-the-valorant-ouroboros.git
+cd six-degrees-of-defeat-the-valorant-ouroboros
 ```
 
 2. 試合データをダウンロード
 ```bash
-./data_processor.sh
+./scripts/data_processor.sh
 ```
 
 3. APIを起動
 ```bash
-./run_api.sh
+./scripts/run_api.sh
 ```
 
 APIサーバーは `http://127.0.0.1:8000` で起動します。


### PR DESCRIPTION
This PR updates the `README.md` to fix some incorrect information.

**Changes:**
- Replaced the placeholder repository name with the actual one.
- Corrected an incorrect path in the usage examples.

This will make the documentation more accurate for new users and contributors. Please take a look.